### PR TITLE
Delete .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,0 @@
-TOKEN=""
-COMMAND_PREFIX="$"
-
-# MongoDB Setup
-# replace `<username>` & `<password>` with correct database user
-#CLUSTER_AUTH_URL="mongodb+srv://CFdealer:sXo9SRRAvjdmZhJA@cluster0.ixh7ysl.mongodb.net/?retryWrites=true&w=majority"
-CLUSTER_AUTH_URL="mongodb+srv://<username>:<password>@cftable1.an4kjw8.mongodb.net/?retryWrites=true&w=majority"
-DB_NAME="CFtable1"


### PR DESCRIPTION
.env file won't be needed in replit, as secrets feature on replit is used for keeping track of important passwords and information